### PR TITLE
Example sketch Temperature is in Fahrenheit

### DIFF
--- a/examples/TinyDHT_TestUno.ino
+++ b/examples/TinyDHT_TestUno.ino
@@ -41,7 +41,7 @@ void loop() {
     Serial.print(" %\t");
     Serial.print("Temperature: "); 
     Serial.print(t);
-    Serial.println(" *C");
+    Serial.println(" *F");
   }
   delay(2000);
 }


### PR DESCRIPTION
The Serial is printing the temperature with the label " *C" which I assumed was celsius, however `dht.readTemperature(1);` reads the integer value in Fahrenheit. This changes the printed output to use the correct units.